### PR TITLE
Bug 1003788 - [marionette-apps] switchToApp method doesn't wait for the app is rendered on screen.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,8 @@ b2g:
 lint:
 	gjslint  --recurse . \
 		--disable "210,217,220,225,0212" \
-		--exclude_directories "b2g,examples,node_modules"
-
-.PHONY: test-sync
-test-sync:
-	SYNC=true ./node_modules/.bin/marionette-mocha $(MOCHA_OPTS)
-
-.PHONY: test-async
-test-async:
-	./node_modules/.bin/marionette-mocha $(MOCHA_OPTS)
+		--exclude_directories "b2g,examples,node_modules"	
 
 .PHONY: test
-test: b2g test-sync test-async
+test: b2g
+	SYNC=true ./node_modules/.bin/marionette-mocha $(MOCHA_OPTS)

--- a/lib/launch.js
+++ b/lib/launch.js
@@ -4,14 +4,6 @@ var getApp = require('./getapp').getApp;
 var url = require('url');
 var fsPath = require('path');
 
-
-/**
- * Origin for the homescreen app.
- * TODO: pull this from settings rather than hardcode.
- * @const {string}
- */
-var HOMESCREEN_ORIGIN = 'homescreen.gaiamobile.org';
-
 /**
  * Launch an application based on its origin and optionally entrypoint.
  * Will wait until app's iframe is visible before firing callback.
@@ -33,8 +25,20 @@ function launch(apps, origin, entrypoint, callback) {
 
   callback = callback || apps._client.defaultCallback;
 
-  // wait for homescreen before launching
-  waitForApp(apps, HOMESCREEN_ORIGIN);
+  // Wait for Homescreen app is rendered.
+  var client = apps._client.scope({ searchTimeout: 10000 });
+  client.waitFor(function() {
+    var el = client.findElement('iframe[src*="homescreen.gaiamobile.org"]');
+    var frameClass = el.scriptWith(function(el) {
+      return el.parentNode.getAttribute('class');
+    });
+
+    if (frameClass !== null) {
+      return frameClass.indexOf('render') !== -1;
+    } else {
+      return el.displayed();
+    }
+  });
 
   // launch the given app
   return getApp(apps, origin, entrypoint, function(err, app) {

--- a/lib/waitforapp.js
+++ b/lib/waitforapp.js
@@ -3,12 +3,10 @@
  */
 var SEARCH_TIMEOUT = 10000;
 
-
 /**
  * @const {number}
  */
 var WAIT_BETWEEN_CHECKS = 250;
-
 
 /**
  * Wait until the app is visible.
@@ -22,7 +20,7 @@ function waitForApp(apps, source, callback) {
   if (client.isSync) {
     waitForAppSync(client, source, callback);
   } else {
-    waitForAppAsync(client, source, callback);
+    throw Error('No longer support async driver. Please use sync driver.');
   }
 }
 
@@ -34,42 +32,35 @@ function waitForApp(apps, source, callback) {
  * @param {Function} callback [Err error, Marionette.Element el].
  */
 function waitForAppSync(client, source, callback) {
-  var selector = 'iframe[src*="' + source + '"]';
+  var el = client.findElement('iframe[src*="' + source + '"]');
 
-  // find iframe
-  var el = client.findElement(selector);
+  // Wait for the iframe is rendered.
   client.waitFor(function() {
-    return el.displayed;
+    var frameClass = el.scriptWith(function(el) {
+      return el.parentNode.getAttribute('class');
+    });
+
+    if (frameClass !== null) {
+      return frameClass.indexOf('render') !== -1;
+    } else {
+      return true;
+    }
+  });
+
+  // Wait for the iframe is displayed on screen.
+  client.waitFor(function() {
+    var transitionState = el.scriptWith(function(el) {
+      return el.parentNode.getAttribute('transition-state');
+    });
+
+    if (transitionState !== null) {
+      return transitionState === 'opened';
+    } else {
+      return el.displayed();
+    }
   });
 
   callback && callback(null, el);
 }
-
-
-/**
- * Wait until the app is visible using an async driver.
- * @param {Marionette.Client} client with async driver.
- * @param {String} source to wait for.
- * @param {Function} callback [Err error, Marionette.Element el].
- */
-function waitForAppAsync(client, source, callback) {
-  var selector = 'iframe[src*="' + source + '"]';
-
-  // find iframe
-  client.findElement(selector, function(err, element) {
-    if (err) {
-      return callback && callback(err);
-    }
-
-    function displayed(done) {
-      element.displayed(done);
-    }
-
-    client.waitFor(displayed, function(err) {
-      callback && callback(err, element);
-    });
-  });
-}
-
 
 module.exports.waitForApp = waitForApp;

--- a/test/waitforapp_test.js
+++ b/test/waitforapp_test.js
@@ -28,8 +28,35 @@ suite('waitforapp', function() {
       });
     });
 
+    test('iframe is with the render class', function(done) {
+      client.findElement('iframe[src*="' + domain + '"]', function(err, el) {
+        el.scriptWith(
+          function(el) {
+            return el.parentNode.getAttribute('class');
+          },
+          function(err, value) {
+            assert.ok(value.indexOf('render') !== -1);
+            done();
+          }
+        );
+      });
+    });
+
+    test('the transition-state of the iframe is opened', function(done) {
+      client.findElement('iframe[src*="' + domain + '"]', function(err, el) {
+        el.scriptWith(
+          function(el) {
+            return el.parentNode.getAttribute('transition-state');
+          },
+          function(err, value) {
+            assert.equal(value, 'opened');
+            done();
+          }
+        );
+      });
+    });
+
     test('iframe is visible', function(done) {
-      var iframe;
       client.findElement('iframe[src*="' + domain + '"]', function(err, el) {
         el.displayed(function(err, displayed) {
           assert.ok(displayed);


### PR DESCRIPTION
Wait for transition state of app's frame as opened.

And we remove the async driver support for two reasons:
1. We don't do the async things for marionette tests in Gaia anymore.
2. We don't need to have sync and async version of the workaround at https://github.com/evanxd/marionette-apps/blob/13318c182ba2f1908bed165c1181583a5ba9cd64/lib/launch.js#L28-L43.

http://bugzil.la/1003788
