### PR TITLE
set default script timeout when launching.

### DIFF
--- a/lib/launch.js
+++ b/lib/launch.js
@@ -46,7 +46,8 @@ function launch(apps, origin, entrypoint, callback) {
   callback = callback || apps._client.defaultCallback;
 
   // Wait for Homescreen app is rendered.
-  var client = apps._client.scope({ searchTimeout: 10000 });
+  var client = apps._client.scope({ searchTimeout: 10000,
+                                    scriptTimeout: 10000 });
   var homescreenApp = getHomescreen(client);
 
   client.waitFor(function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marionette-apps",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "author": {
     "name": "Gareth Aye",
     "email": "gaye@mozilla.com"


### PR DESCRIPTION
The default timeout is not enough for testing against devices after a b2g restart. Increasing the timeout gives the phone enough time to run the script and return.
