### PR TITLE
Bug 1097591 - Do not explode if the home screen frame has not been constructed yet

### DIFF
--- a/lib/launch.js
+++ b/lib/launch.js
@@ -51,7 +51,13 @@ function launch(apps, origin, entrypoint, callback) {
   var homescreenApp = getHomescreen(client);
 
   client.waitFor(function() {
-    var el = client.findElement('iframe[src*="' + homescreenApp + '"]');
+    var el;
+    try {
+      el = client.findElement('iframe[src*="' + homescreenApp + '"]');
+    } catch (e) {
+      return false;
+    }
+
     var frameClass = el.scriptWith(function(el) {
       return el.parentNode.getAttribute('class');
     });


### PR DESCRIPTION
This is kind of a guess, but I think this could possibly help?

https://bugzilla.mozilla.org/show_bug.cgi?id=1097591
